### PR TITLE
SPDX License Identifier로 변경

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,8 +19,8 @@ source=(
 url='https://www.kakaocorp.com/page/service/service/KakaoTalk'
 
 license=(
-    'custom:kakaotalk'
-    'unlicense'
+    'LicenseRef-KakaoTalk'
+    'Unlicense'
 )
 
 depends=(


### PR DESCRIPTION
패키지 빌드 시 `pkgctl`과 같은 방식을 이용하면 라이선스 관련 오류가 발생합니다.
오류가 있어도 패키지 생성은 가능하나, 되도록 [가이드라인](https://wiki.archlinux.org/title/Arch_package_guidelines#PKGBUILD's_license_field)에 맞게 쓰는 편이 좋지 않을까 생각됩니다.